### PR TITLE
wsl

### DIFF
--- a/internal/scanner/ip4/arp.go
+++ b/internal/scanner/ip4/arp.go
@@ -5,6 +5,7 @@ import (
 	"runtime"
 	"strings"
 
+	"github.com/backendsystems/nibble/internal/scanner/ip4/docker"
 	"github.com/backendsystems/nibble/internal/scanner/ip4/linux"
 	"github.com/backendsystems/nibble/internal/scanner/ip4/macos"
 	"github.com/backendsystems/nibble/internal/scanner/ip4/windows"
@@ -36,7 +37,22 @@ type NeighborEntry struct {
 
 // visibleNeighbors returns neighbors currently visible in the OS ARP
 // table for the selected interface and subnet
-func visibleNeighbors(ifaceName string, subnet *net.IPNet) []NeighborEntry {
+// visibleNeighbors returns neighbors from the OS ARP table or Docker daemon.
+// The second return value is true when the result is exhaustive — i.e. came
+// from the Docker socket — meaning no subnet sweep is needed.
+func (s *Scanner) visibleNeighbors(ifaceName string, subnet *net.IPNet) ([]NeighborEntry, bool) {
+	// For Docker bridge interfaces, the daemon knows exactly which containers
+	// are running — skip the ARP table entirely.
+	if _, ok := s.dockerIfaces[ifaceName]; ok {
+		if dockerNeighbors := docker.ContainerNeighbors(ifaceName, subnet); len(dockerNeighbors) > 0 {
+			out := make([]NeighborEntry, len(dockerNeighbors))
+			for i, n := range dockerNeighbors {
+				out[i] = NeighborEntry{IP: n.IP, MAC: n.MAC}
+			}
+			return out, true
+		}
+	}
+
 	var rows []NeighborEntry
 	switch runtime.GOOS {
 	case "windows":
@@ -49,7 +65,6 @@ func visibleNeighbors(ifaceName string, subnet *net.IPNet) []NeighborEntry {
 		}
 	default:
 		if strings.HasPrefix(ifaceName, "win:") {
-			// WSL: scan Windows host interface via interop
 			for _, row := range wsl.Neighbors(ifaceName) {
 				rows = append(rows, NeighborEntry{IP: row.IP, MAC: row.MAC})
 			}
@@ -82,7 +97,7 @@ func visibleNeighbors(ifaceName string, subnet *net.IPNet) []NeighborEntry {
 		seen[row.IP] = struct{}{}
 		out = append(out, row)
 	}
-	return out
+	return out, false
 }
 
 func isSubnetBroadcastIpv4(ip net.IP, subnet *net.IPNet) bool {

--- a/internal/scanner/ip4/arp.go
+++ b/internal/scanner/ip4/arp.go
@@ -8,6 +8,7 @@ import (
 	"github.com/backendsystems/nibble/internal/scanner/ip4/linux"
 	"github.com/backendsystems/nibble/internal/scanner/ip4/macos"
 	"github.com/backendsystems/nibble/internal/scanner/ip4/windows"
+	"github.com/backendsystems/nibble/internal/scanner/ip4/wsl"
 )
 
 // lookupMacFromCache reads the OS ARP cache to find a MAC without needing root
@@ -18,6 +19,11 @@ func lookupMacFromCache(ip string) string {
 	}
 	if runtime.GOOS == "darwin" {
 		return macos.LookupMAC(ip)
+	}
+	if wsl.IsWSL() {
+		if mac := wsl.LookupMAC(ip); mac != "" {
+			return mac
+		}
 	}
 	return linux.LookupMAC(ip)
 }
@@ -42,8 +48,15 @@ func visibleNeighbors(ifaceName string, subnet *net.IPNet) []NeighborEntry {
 			rows = append(rows, NeighborEntry{IP: row.IP, MAC: row.MAC})
 		}
 	default:
-		for _, row := range linux.Neighbors(ifaceName) {
-			rows = append(rows, NeighborEntry{IP: row.IP, MAC: row.MAC})
+		if strings.HasPrefix(ifaceName, "win:") {
+			// WSL: scan Windows host interface via interop
+			for _, row := range wsl.Neighbors(ifaceName) {
+				rows = append(rows, NeighborEntry{IP: row.IP, MAC: row.MAC})
+			}
+		} else {
+			for _, row := range linux.Neighbors(ifaceName) {
+				rows = append(rows, NeighborEntry{IP: row.IP, MAC: row.MAC})
+			}
 		}
 	}
 

--- a/internal/scanner/ip4/docker/docker.go
+++ b/internal/scanner/ip4/docker/docker.go
@@ -1,0 +1,159 @@
+package docker
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+)
+
+const socketPath = "/var/run/docker.sock"
+
+// Neighbor is a container visible on a Docker bridge network.
+type Neighbor struct {
+	IP  string
+	MAC string
+}
+
+func client() *http.Client {
+	return &http.Client{
+		Timeout: 2 * time.Second,
+		Transport: &http.Transport{
+			DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+				return (&net.Dialer{}).DialContext(ctx, "unix", socketPath)
+			},
+		},
+	}
+}
+
+// Networks queries the Docker daemon and returns a map of kernel bridge interface
+// name (e.g. "br-09ff0748a767") to human-readable Docker network name
+// (e.g. "myproject_default"). Returns nil if the socket is unavailable.
+func Networks() map[string]string {
+	resp, err := client().Get("http://localhost/networks")
+	if err != nil {
+		return nil
+	}
+	defer resp.Body.Close()
+
+	var networks []struct {
+		Name string `json:"Name"`
+		ID   string `json:"Id"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&networks); err != nil {
+		return nil
+	}
+
+	result := make(map[string]string, len(networks))
+	for _, n := range networks {
+		if len(n.ID) >= 12 {
+			result["br-"+n.ID[:12]] = n.Name
+		}
+	}
+	return result
+}
+
+// IsBridgeIface returns true if the kernel interface name belongs to a Docker
+// network, using the map returned by Networks(). Falls back to name-prefix
+// heuristic (docker0, br-*) when the socket was unavailable and networks is nil.
+func IsBridgeIface(kernelName string, networks map[string]string) bool {
+	if networks != nil {
+		_, ok := networks[kernelName]
+		return ok
+	}
+	return kernelName == "docker0" || strings.HasPrefix(kernelName, "br-")
+}
+
+// BridgeHasPeers returns true if the bridge has at least one veth peer attached,
+// meaning at least one container is connected. Uses sysfs rather than ARP cache
+// so idle-but-running containers are not incorrectly filtered out.
+func BridgeHasPeers(name string) bool {
+	entries, err := os.ReadDir("/sys/class/net/" + name + "/brif")
+	return err == nil && len(entries) > 0
+}
+
+// ApplyNetworkNames renames any Docker bridge entries in ifaces and addrsByIface
+// to their human-readable Docker network names. Returns the set of display names
+// that correspond to Docker networks, for use in scan-time lookups.
+func ApplyNetworkNames(ifaces []net.Interface, addrsByIface map[string][]net.Addr, networks map[string]string) map[string]struct{} {
+	dockerDisplayNames := make(map[string]struct{}, len(networks))
+	for i, iface := range ifaces {
+		dockerName, ok := networks[iface.Name]
+		if !ok {
+			// No rename — track under the kernel name if it's a bridge.
+			if strings.HasPrefix(iface.Name, "br-") || iface.Name == "docker0" {
+				dockerDisplayNames[iface.Name] = struct{}{}
+			}
+			continue
+		}
+		addrs := addrsByIface[iface.Name]
+		delete(addrsByIface, iface.Name)
+		addrsByIface[dockerName] = addrs
+		ifaces[i].Name = dockerName
+		dockerDisplayNames[dockerName] = struct{}{}
+	}
+	return dockerDisplayNames
+}
+
+// ContainerNeighbors queries the Docker daemon and returns the IP and MAC of
+// every running container attached to networkName that falls within subnet.
+// Returns nil if the socket is unavailable.
+func ContainerNeighbors(networkName string, subnet *net.IPNet) []Neighbor {
+	resp, err := client().Get("http://localhost/containers/json")
+	if err != nil {
+		return nil
+	}
+	defer resp.Body.Close()
+
+	var containers []struct {
+		NetworkSettings struct {
+			Networks map[string]struct {
+				IPAddress  string `json:"IPAddress"`
+				MacAddress string `json:"MacAddress"`
+			} `json:"Networks"`
+		} `json:"NetworkSettings"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&containers); err != nil {
+		return nil
+	}
+
+	var out []Neighbor
+	for _, c := range containers {
+		for name, ns := range c.NetworkSettings.Networks {
+			if name != networkName {
+				continue
+			}
+			ip := net.ParseIP(ns.IPAddress)
+			if ip == nil || !subnet.Contains(ip) {
+				continue
+			}
+			out = append(out, Neighbor{IP: ns.IPAddress, MAC: ns.MacAddress})
+		}
+	}
+	return out
+}
+
+// ClampToCIDR returns addrs with any IPv4 prefix longer than bits clamped to bits.
+func ClampToCIDR(addrs []net.Addr, bits int) []net.Addr {
+	out := make([]net.Addr, 0, len(addrs))
+	for _, addr := range addrs {
+		ipnet, ok := addr.(*net.IPNet)
+		if !ok {
+			out = append(out, addr)
+			continue
+		}
+		ones, total := ipnet.Mask.Size()
+		if total == 32 && ones > bits {
+			out = append(out, &net.IPNet{
+				IP:   ipnet.IP,
+				Mask: net.CIDRMask(bits, 32),
+			})
+		} else {
+			out = append(out, addr)
+		}
+	}
+	return out
+}

--- a/internal/scanner/ip4/interfaces.go
+++ b/internal/scanner/ip4/interfaces.go
@@ -3,9 +3,12 @@ package ip4
 import (
 	"net"
 	"net/netip"
+
+	"github.com/backendsystems/nibble/internal/scanner/ip4/wsl"
 )
 
 // GetInterfaces returns active non-loopback interfaces with at least one IPv4 address.
+// When running inside WSL, Windows host interfaces are also included via interop.
 func (s *Scanner) GetInterfaces() ([]net.Interface, map[string][]net.Addr, error) {
 	sysIfaces, err := net.Interfaces()
 	if err != nil {
@@ -32,6 +35,19 @@ func (s *Scanner) GetInterfaces() ([]net.Interface, map[string][]net.Addr, error
 		if hasIp4(addrs) {
 			ifaces = append(ifaces, iface)
 			addrsByIface[iface.Name] = addrs
+		}
+	}
+
+	// In WSL, also include Windows host interfaces via interop.
+	if wsl.IsWSL() {
+		for _, wiface := range wsl.Interfaces() {
+			ifaces = append(ifaces, net.Interface{
+				Index:        wiface.Index,
+				Name:         wiface.Name,
+				HardwareAddr: wiface.HWAddr,
+				Flags:        net.FlagUp | net.FlagBroadcast | net.FlagMulticast,
+			})
+			addrsByIface[wiface.Name] = wiface.Addrs
 		}
 	}
 

--- a/internal/scanner/ip4/interfaces.go
+++ b/internal/scanner/ip4/interfaces.go
@@ -32,7 +32,7 @@ func (s *Scanner) GetInterfaces() ([]net.Interface, map[string][]net.Addr, error
 			continue
 		}
 
-		if hasIp4(addrs) {
+		if hasIp4(addrs) && !wsl.IsWSLVirtualIface(iface.Name) {
 			ifaces = append(ifaces, iface)
 			addrsByIface[iface.Name] = addrs
 		}

--- a/internal/scanner/ip4/interfaces.go
+++ b/internal/scanner/ip4/interfaces.go
@@ -4,6 +4,7 @@ import (
 	"net"
 	"net/netip"
 
+	"github.com/backendsystems/nibble/internal/scanner/ip4/docker"
 	"github.com/backendsystems/nibble/internal/scanner/ip4/wsl"
 )
 
@@ -15,14 +16,15 @@ func (s *Scanner) GetInterfaces() ([]net.Interface, map[string][]net.Addr, error
 		return nil, nil, err
 	}
 
+	// Fetch Docker network info once — used for detection, clamping, and renaming.
+	dockerNetworks := docker.Networks()
+
 	ifaces := make([]net.Interface, 0, len(sysIfaces))
 	addrsByIface := make(map[string][]net.Addr, len(sysIfaces))
 	for _, iface := range sysIfaces {
-		// Skip loopback interfaces.
 		if iface.Flags&net.FlagLoopback != 0 {
 			continue
 		}
-		// Skip interfaces that are down.
 		if iface.Flags&net.FlagUp == 0 {
 			continue
 		}
@@ -32,10 +34,19 @@ func (s *Scanner) GetInterfaces() ([]net.Interface, map[string][]net.Addr, error
 			continue
 		}
 
-		if hasIp4(addrs) && !wsl.IsWSLVirtualIface(iface.Name) {
-			ifaces = append(ifaces, iface)
-			addrsByIface[iface.Name] = addrs
+		if !hasIp4(addrs) || wsl.IsWSLVirtualIface(iface.Name) {
+			continue
 		}
+
+		if docker.IsBridgeIface(iface.Name, dockerNetworks) {
+			if !docker.BridgeHasPeers(iface.Name) {
+				continue
+			}
+			addrs = docker.ClampToCIDR(addrs, 24)
+		}
+
+		ifaces = append(ifaces, iface)
+		addrsByIface[iface.Name] = addrs
 	}
 
 	// In WSL, also include Windows host interfaces via interop.
@@ -51,7 +62,62 @@ func (s *Scanner) GetInterfaces() ([]net.Interface, map[string][]net.Addr, error
 		}
 	}
 
+	ifaces, addrsByIface = deduplicateSubnets(ifaces, addrsByIface)
+	s.dockerIfaces = docker.ApplyNetworkNames(ifaces, addrsByIface, dockerNetworks)
+
 	return ifaces, addrsByIface, nil
+}
+
+// deduplicateSubnets removes interfaces whose IPv4 address is already contained
+// within another interface's subnet. This prevents showing redundant cards when
+// multiple interfaces share the same network (e.g. eth0/24 and services1/32 on
+// the same 192.168.65.0/24).
+func deduplicateSubnets(ifaces []net.Interface, addrsByIface map[string][]net.Addr) ([]net.Interface, map[string][]net.Addr) {
+	// Collect all subnets with their prefix length so we prefer the broader one.
+	type ifaceSubnet struct {
+		ones int
+		net  *net.IPNet
+	}
+	var subnets []ifaceSubnet
+	for _, iface := range ifaces {
+		for _, addr := range addrsByIface[iface.Name] {
+			ipnet, ok := addr.(*net.IPNet)
+			if ok && ipnet.IP.To4() != nil {
+				ones, _ := ipnet.Mask.Size()
+				subnets = append(subnets, ifaceSubnet{ones: ones, net: ipnet})
+			}
+		}
+	}
+
+	out := make([]net.Interface, 0, len(ifaces))
+	outAddrs := make(map[string][]net.Addr, len(ifaces))
+	for _, iface := range ifaces {
+		covered := false
+		for _, addr := range addrsByIface[iface.Name] {
+			ipnet, ok := addr.(*net.IPNet)
+			if !ok || ipnet.IP.To4() == nil {
+				continue
+			}
+			ones, _ := ipnet.Mask.Size()
+			for _, s := range subnets {
+				if s.net == ipnet {
+					continue // skip self
+				}
+				if s.ones < ones && s.net.Contains(ipnet.IP) {
+					covered = true
+					break
+				}
+			}
+			if covered {
+				break
+			}
+		}
+		if !covered {
+			out = append(out, iface)
+			outAddrs[iface.Name] = addrsByIface[iface.Name]
+		}
+	}
+	return out, outAddrs
 }
 
 func hasIp4(addrs []net.Addr) bool {
@@ -65,17 +131,13 @@ func hasIp4(addrs []net.Addr) bool {
 }
 
 func parseAddr(s string) (netip.Addr, bool) {
-	// addresses may be CIDR "192.168.1.10/24"
 	prefix, err := netip.ParsePrefix(s)
 	if err == nil {
 		return prefix.Addr(), true
 	}
-
-	// or plain "192.168.1.10"
 	ip, err := netip.ParseAddr(s)
 	if err == nil {
 		return ip, true
 	}
-
 	return netip.Addr{}, false
 }

--- a/internal/scanner/ip4/neighbours.go
+++ b/internal/scanner/ip4/neighbours.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/backendsystems/nibble/internal/scanner/ip4/wsl"
 	"github.com/backendsystems/nibble/internal/scanner/shared"
 )
 
@@ -22,6 +23,9 @@ var dialExtra = func() time.Duration {
 	case "windows":
 		return 50 * time.Millisecond
 	default:
+		if wsl.IsWSL() {
+			return 50 * time.Millisecond
+		}
 		return 0
 	}
 }()

--- a/internal/scanner/ip4/scan.go
+++ b/internal/scanner/ip4/scan.go
@@ -9,7 +9,8 @@ import (
 
 // Scanner performs real network scanning (TCP connect, ARP, banner grab)
 type Scanner struct {
-	Ports []int
+	Ports        []int
+	dockerIfaces map[string]struct{} // display names of Docker network interfaces
 }
 
 // ScanNetwork scans a real subnet with controlled concurrency for smooth progress
@@ -25,10 +26,18 @@ func (s *Scanner) ScanNetwork(ifaceName, subnet string, progressChan chan<- shar
 
 	// Skip neighbor discovery for target scans (when no interface specified)
 	var skipIPs map[string]struct{}
+	var exhaustive bool
 	if ifaceName != "" {
-		skipIPs = s.neighborDiscovery(ifaceName, ipnet, totalHosts, progressChan)
+		skipIPs, exhaustive = s.neighborDiscovery(ifaceName, ipnet, totalHosts, progressChan)
 	} else {
 		skipIPs = make(map[string]struct{})
+	}
+
+	if exhaustive {
+		// Docker socket gave us the complete container list — no sweep needed.
+		// Emit a final SweepProgress so the progress bar reaches 100%.
+		progressChan <- shared.SweepProgress{TotalHosts: totalHosts, Scanned: totalHosts}
+		return
 	}
 
 	s.subnetSweep(ifaceName, ipnet, totalHosts, skipIPs, progressChan)

--- a/internal/scanner/ip4/targets.go
+++ b/internal/scanner/ip4/targets.go
@@ -26,14 +26,15 @@ func newMaxWorkers() int {
 	}
 }
 
-// neighborDiscovery emits hosts already visible in neighbor tables
-// and returns IPs that should be skipped in the full sweep
-func (s *Scanner) neighborDiscovery(ifaceName string, subnet *net.IPNet, totalHosts int, progressChan chan<- shared.ProgressUpdate) map[string]struct{} {
-	neighbors := visibleNeighbors(ifaceName, subnet)
+// neighborDiscovery emits hosts already visible in neighbor tables.
+// Returns the set of IPs to skip in the sweep, and whether discovery was
+// exhaustive (true when the Docker socket was used and no sweep is needed).
+func (s *Scanner) neighborDiscovery(ifaceName string, subnet *net.IPNet, totalHosts int, progressChan chan<- shared.ProgressUpdate) (map[string]struct{}, bool) {
+	neighbors, exhaustive := s.visibleNeighbors(ifaceName, subnet)
 	skipIPs := buildSkipMap(neighbors)
 	if len(neighbors) == 0 {
 		emitNeighborProgress(progressChan, shared.NeighborProgress{TotalHosts: totalHosts})
-		return skipIPs
+		return skipIPs, exhaustive
 	}
 
 	ports := s.ports()
@@ -57,7 +58,7 @@ func (s *Scanner) neighborDiscovery(ifaceName string, subnet *net.IPNet, totalHo
 	close(jobs)
 
 	wg.Wait()
-	return skipIPs
+	return skipIPs, exhaustive
 }
 
 // subnetSweep scans the subnet and skips hosts found in neighbor discovery

--- a/internal/scanner/ip4/wsl/arp.go
+++ b/internal/scanner/ip4/wsl/arp.go
@@ -14,27 +14,19 @@ type Neighbor struct {
 }
 
 // Neighbors returns ARP entries from the Windows ARP table via arp.exe.
-func Neighbors(winIfaceName string) []Neighbor {
-	alias := strings.TrimPrefix(winIfaceName, "win:")
-
+// winIfaceName is accepted for API compatibility but unused: arp.exe sections
+// are identified by IP address, not interface name, and visibleNeighbors
+// already filters entries to the correct subnet.
+func Neighbors(_ string) []Neighbor {
 	out, err := runWinCmd("arp.exe", "-a")
 	if err != nil {
 		return nil
 	}
 
 	var rows []Neighbor
-	inSection := alias == "" // if no alias filter, include all
 	for line := range strings.SplitSeq(out, "\n") {
 		line = strings.TrimSpace(line)
-		if line == "" {
-			continue
-		}
-		// Section headers look like: "Interface: 192.168.1.5 --- 0x4"
-		if strings.HasPrefix(line, "Interface:") {
-			inSection = alias == ""
-			continue
-		}
-		if !inSection {
+		if line == "" || strings.HasPrefix(line, "Interface:") {
 			continue
 		}
 		fields := strings.Fields(line)

--- a/internal/scanner/ip4/wsl/arp.go
+++ b/internal/scanner/ip4/wsl/arp.go
@@ -1,0 +1,65 @@
+package wsl
+
+import (
+	"net"
+	"strings"
+
+	"github.com/backendsystems/nibble/internal/scanner/shared"
+)
+
+// Neighbor is an ARP entry from the Windows ARP table.
+type Neighbor struct {
+	IP  string
+	MAC string
+}
+
+// Neighbors returns ARP entries from the Windows ARP table via arp.exe.
+func Neighbors(winIfaceName string) []Neighbor {
+	alias := strings.TrimPrefix(winIfaceName, "win:")
+
+	out, err := runWinCmd("arp.exe", "-a")
+	if err != nil {
+		return nil
+	}
+
+	var rows []Neighbor
+	inSection := alias == "" // if no alias filter, include all
+	for line := range strings.SplitSeq(out, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		// Section headers look like: "Interface: 192.168.1.5 --- 0x4"
+		if strings.HasPrefix(line, "Interface:") {
+			inSection = alias == ""
+			continue
+		}
+		if !inSection {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+		ip := fields[0]
+		if net.ParseIP(ip) == nil {
+			continue
+		}
+		mac := shared.NormalizeMAC(fields[1])
+		if mac == "" || mac == "00:00:00:00:00:00" || strings.EqualFold(mac, "ff:ff:ff:ff:ff:ff") {
+			continue
+		}
+		rows = append(rows, Neighbor{IP: ip, MAC: mac})
+	}
+	return rows
+}
+
+// LookupMAC looks up a MAC address from the Windows ARP table.
+func LookupMAC(ip string) string {
+	for _, n := range Neighbors("") {
+		if n.IP == ip {
+			return n.MAC
+		}
+	}
+	return ""
+}

--- a/internal/scanner/ip4/wsl/exec.go
+++ b/internal/scanner/ip4/wsl/exec.go
@@ -2,11 +2,39 @@ package wsl
 
 import (
 	"bytes"
+	"os"
 	"os/exec"
+	"path/filepath"
+	"strings"
 )
 
+// winCmdPath resolves a Windows executable name to its full path inside WSL.
+// It first checks $WINDIR (set by WSL from the Windows environment), then falls
+// back to the conventional mount point /mnt/c/Windows/System32.
+func winCmdPath(name string) string {
+	if windir := os.Getenv("WINDIR"); windir != "" {
+		// WINDIR is a Windows path like "C:\Windows"; translate the drive letter.
+		// e.g. "C:\Windows" -> "/mnt/c/Windows"
+		if len(windir) >= 2 && windir[1] == ':' {
+			drive := strings.ToLower(string(windir[0]))
+			rest := filepath.ToSlash(windir[2:])
+			candidate := "/mnt/" + drive + rest + "/System32/" + name
+			if _, err := os.Stat(candidate); err == nil {
+				return candidate
+			}
+		}
+	}
+	// Conventional fallback
+	fallback := "/mnt/c/Windows/System32/" + name
+	if _, err := os.Stat(fallback); err == nil {
+		return fallback
+	}
+	// Last resort: let the shell find it (works when Windows paths are in $PATH)
+	return name
+}
+
 func runWinCmd(name string, args ...string) (string, error) {
-	cmd := exec.Command(name, args...)
+	cmd := exec.Command(winCmdPath(name), args...)
 	var buf bytes.Buffer
 	cmd.Stdout = &buf
 	if err := cmd.Run(); err != nil {
@@ -15,23 +43,3 @@ func runWinCmd(name string, args ...string) (string, error) {
 	return buf.String(), nil
 }
 
-type cidrAddr struct {
-	cidr string
-}
-
-func (c cidrAddr) Network() string { return "ip+net" }
-func (c cidrAddr) String() string  { return c.cidr }
-
-func itoa(n int) string {
-	if n == 0 {
-		return "0"
-	}
-	buf := [3]byte{}
-	pos := 2
-	for n > 0 {
-		buf[pos] = byte('0' + n%10)
-		n /= 10
-		pos--
-	}
-	return string(buf[pos+1:])
-}

--- a/internal/scanner/ip4/wsl/exec.go
+++ b/internal/scanner/ip4/wsl/exec.go
@@ -1,0 +1,37 @@
+package wsl
+
+import (
+	"bytes"
+	"os/exec"
+)
+
+func runWinCmd(name string, args ...string) (string, error) {
+	cmd := exec.Command(name, args...)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return buf.String(), nil
+}
+
+type cidrAddr struct {
+	cidr string
+}
+
+func (c cidrAddr) Network() string { return "ip+net" }
+func (c cidrAddr) String() string  { return c.cidr }
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	buf := [3]byte{}
+	pos := 2
+	for n > 0 {
+		buf[pos] = byte('0' + n%10)
+		n /= 10
+		pos--
+	}
+	return string(buf[pos+1:])
+}

--- a/internal/scanner/ip4/wsl/interfaces.go
+++ b/internal/scanner/ip4/wsl/interfaces.go
@@ -29,17 +29,19 @@ func Interfaces() []Interface {
 func parseIpconfig(out string) []Interface {
 	var result []Interface
 	var cur *Interface
+	var pendingIP net.IP
 	var curMask net.IP
 
 	commit := func() {
 		if cur == nil {
 			return
 		}
-		// apply any pending mask to the last address added
-		if curMask != nil && len(cur.Addrs) > 0 {
-			cur.Addrs[len(cur.Addrs)-1] = applyMask(cur.Addrs[len(cur.Addrs)-1], curMask)
-			curMask = nil
+		// flush any IP that never got its mask
+		if pendingIP != nil {
+			cur.Addrs = append(cur.Addrs, &net.IPNet{IP: pendingIP, Mask: net.CIDRMask(32, 32)})
+			pendingIP = nil
 		}
+		curMask = nil
 		if len(cur.Addrs) > 0 {
 			result = append(result, *cur)
 		}
@@ -55,7 +57,7 @@ func parseIpconfig(out string) []Interface {
 			commit()
 			name := strings.TrimSuffix(strings.TrimSpace(line), ":")
 			lower := strings.ToLower(name)
-			if strings.Contains(lower, "loopback") || strings.Contains(lower, "tunnel") || strings.Contains(lower, "teredo") {
+			if strings.Contains(lower, "loopback") || strings.Contains(lower, "tunnel") || strings.Contains(lower, "teredo") || strings.Contains(lower, "vethernet") {
 				continue
 			}
 			cur = &Interface{Name: "win:" + adapterShortName(name)}
@@ -80,25 +82,31 @@ func parseIpconfig(out string) []Interface {
 
 		case strings.Contains(key, "IPv4 Address"):
 			// value may be "192.168.1.5(Preferred)" or "192.168.1.5"
-			ip := strings.TrimSuffix(strings.TrimSuffix(val, "(Preferred)"), "(Duplicate)")
-			parsed := net.ParseIP(ip)
+			ipStr := strings.TrimSuffix(strings.TrimSuffix(val, "(Preferred)"), "(Duplicate)")
+			parsed := net.ParseIP(ipStr).To4()
 			if parsed == nil || parsed.IsLinkLocalUnicast() || parsed.IsLoopback() {
 				continue
 			}
-			// push a placeholder addr; mask comes on the next line
-			if curMask != nil && len(cur.Addrs) > 0 {
-				cur.Addrs[len(cur.Addrs)-1] = applyMask(cur.Addrs[len(cur.Addrs)-1], curMask)
-				curMask = nil
+			// flush any previous pending IP that never got a mask
+			if pendingIP != nil {
+				cur.Addrs = append(cur.Addrs, &net.IPNet{IP: pendingIP, Mask: net.CIDRMask(32, 32)})
 			}
-			cur.Addrs = append(cur.Addrs, cidrAddr{cidr: ip + "/32"}) // placeholder until mask
+			if curMask != nil {
+				cur.Addrs = append(cur.Addrs, &net.IPNet{IP: parsed, Mask: net.IPMask(curMask.To4())})
+				pendingIP = nil
+				curMask = nil
+			} else {
+				pendingIP = parsed
+			}
 
 		case strings.Contains(key, "Subnet Mask"):
-			mask := net.ParseIP(val)
+			mask := net.ParseIP(val).To4()
 			if mask == nil {
 				continue
 			}
-			if len(cur.Addrs) > 0 {
-				cur.Addrs[len(cur.Addrs)-1] = applyMask(cur.Addrs[len(cur.Addrs)-1], mask)
+			if pendingIP != nil {
+				cur.Addrs = append(cur.Addrs, &net.IPNet{IP: pendingIP, Mask: net.IPMask(mask)})
+				pendingIP = nil
 			} else {
 				curMask = mask
 			}
@@ -138,18 +146,3 @@ func adapterShortName(header string) string {
 	return header
 }
 
-// applyMask converts a placeholder cidrAddr (IP/32) into a proper CIDR using the subnet mask.
-func applyMask(addr net.Addr, mask net.IP) net.Addr {
-	ca, ok := addr.(cidrAddr)
-	if !ok {
-		return addr
-	}
-	ipStr := strings.TrimSuffix(ca.cidr, "/32")
-	ip := net.ParseIP(ipStr).To4()
-	m := net.IPMask(mask.To4())
-	if ip == nil || m == nil {
-		return addr
-	}
-	ones, _ := m.Size()
-	return cidrAddr{cidr: ip.String() + "/" + itoa(ones)}
-}

--- a/internal/scanner/ip4/wsl/interfaces.go
+++ b/internal/scanner/ip4/wsl/interfaces.go
@@ -1,0 +1,155 @@
+package wsl
+
+import (
+	"net"
+	"strings"
+)
+
+// Interface represents a Windows network interface visible via WSL interop.
+type Interface struct {
+	Name   string
+	Index  int
+	Addrs  []net.Addr
+	HWAddr net.HardwareAddr
+}
+
+// Interfaces returns Windows network interfaces by parsing ipconfig.exe /all output.
+// Each interface is given a synthetic name like "win:Ethernet" to distinguish
+// it from WSL-internal interfaces.
+func Interfaces() []Interface {
+	// ipconfig.exe is a native Win32 binary, much faster to start than PowerShell
+	out, err := runWinCmd("ipconfig.exe", "/all")
+	if err != nil {
+		return nil
+	}
+	return parseIpconfig(out)
+}
+
+// parseIpconfig parses the output of `ipconfig.exe /all` into Interface entries.
+func parseIpconfig(out string) []Interface {
+	var result []Interface
+	var cur *Interface
+	var curMask net.IP
+
+	commit := func() {
+		if cur == nil {
+			return
+		}
+		// apply any pending mask to the last address added
+		if curMask != nil && len(cur.Addrs) > 0 {
+			cur.Addrs[len(cur.Addrs)-1] = applyMask(cur.Addrs[len(cur.Addrs)-1], curMask)
+			curMask = nil
+		}
+		if len(cur.Addrs) > 0 {
+			result = append(result, *cur)
+		}
+		cur = nil
+	}
+
+	for line := range strings.SplitSeq(out, "\n") {
+		line = strings.TrimRight(line, "\r")
+
+		// Adapter section header — not indented, ends with ":"
+		// e.g. "Ethernet adapter Ethernet:" or "Wireless LAN adapter Wi-Fi:"
+		if len(line) > 0 && line[0] != ' ' && line[0] != '\t' {
+			commit()
+			name := strings.TrimSuffix(strings.TrimSpace(line), ":")
+			lower := strings.ToLower(name)
+			if strings.Contains(lower, "loopback") || strings.Contains(lower, "tunnel") || strings.Contains(lower, "teredo") {
+				continue
+			}
+			cur = &Interface{Name: "win:" + adapterShortName(name)}
+			continue
+		}
+
+		if cur == nil {
+			continue
+		}
+
+		key, val, ok := splitIpconfigField(line)
+		if !ok {
+			continue
+		}
+
+		switch {
+		case strings.Contains(key, "Physical Address"):
+			mac, err := net.ParseMAC(strings.ReplaceAll(val, "-", ":"))
+			if err == nil {
+				cur.HWAddr = mac
+			}
+
+		case strings.Contains(key, "IPv4 Address"):
+			// value may be "192.168.1.5(Preferred)" or "192.168.1.5"
+			ip := strings.TrimSuffix(strings.TrimSuffix(val, "(Preferred)"), "(Duplicate)")
+			parsed := net.ParseIP(ip)
+			if parsed == nil || parsed.IsLinkLocalUnicast() || parsed.IsLoopback() {
+				continue
+			}
+			// push a placeholder addr; mask comes on the next line
+			if curMask != nil && len(cur.Addrs) > 0 {
+				cur.Addrs[len(cur.Addrs)-1] = applyMask(cur.Addrs[len(cur.Addrs)-1], curMask)
+				curMask = nil
+			}
+			cur.Addrs = append(cur.Addrs, cidrAddr{cidr: ip + "/32"}) // placeholder until mask
+
+		case strings.Contains(key, "Subnet Mask"):
+			mask := net.ParseIP(val)
+			if mask == nil {
+				continue
+			}
+			if len(cur.Addrs) > 0 {
+				cur.Addrs[len(cur.Addrs)-1] = applyMask(cur.Addrs[len(cur.Addrs)-1], mask)
+			} else {
+				curMask = mask
+			}
+		}
+	}
+	commit()
+	return result
+}
+
+// splitIpconfigField splits a line like "   Physical Address. . . . . : AA-BB-CC-DD-EE-FF"
+// into key="Physical Address" and val="AA-BB-CC-DD-EE-FF".
+func splitIpconfigField(line string) (key, val string, ok bool) {
+	idx := strings.Index(line, " : ")
+	if idx < 0 {
+		return
+	}
+	key = strings.TrimRight(strings.TrimSpace(line[:idx]), ". ")
+	val = strings.TrimSpace(line[idx+3:])
+	ok = true
+	return
+}
+
+// adapterShortName extracts the user-visible name from an ipconfig adapter header.
+// "Ethernet adapter Ethernet" -> "Ethernet"
+// "Wireless LAN adapter Wi-Fi" -> "Wi-Fi"
+func adapterShortName(header string) string {
+	for _, prefix := range []string{
+		"Ethernet adapter ",
+		"Wireless LAN adapter ",
+		"PPP adapter ",
+		"Tunnel adapter ",
+	} {
+		if strings.HasPrefix(header, prefix) {
+			return strings.TrimPrefix(header, prefix)
+		}
+	}
+	return header
+}
+
+// applyMask converts a placeholder cidrAddr (IP/32) into a proper CIDR using the subnet mask.
+func applyMask(addr net.Addr, mask net.IP) net.Addr {
+	ca, ok := addr.(cidrAddr)
+	if !ok {
+		return addr
+	}
+	ipStr := strings.TrimSuffix(ca.cidr, "/32")
+	ip := net.ParseIP(ipStr).To4()
+	m := net.IPMask(mask.To4())
+	if ip == nil || m == nil {
+		return addr
+	}
+	ones, _ := m.Size()
+	return cidrAddr{cidr: ip.String() + "/" + itoa(ones)}
+}

--- a/internal/scanner/ip4/wsl/wsl.go
+++ b/internal/scanner/ip4/wsl/wsl.go
@@ -4,6 +4,17 @@ import (
 	"os"
 )
 
+// IsWSLVirtualIface returns true for virtual network interfaces created by WSL
+// itself (eth0, the Hyper-V NAT adapter) that have no unique scannable network.
+// Windows interfaces are exposed via win: names instead.
+func IsWSLVirtualIface(name string) bool {
+	if !IsWSL() {
+		return false
+	}
+	// eth0 is the WSL Hyper-V NAT adapter — covered by win: interfaces
+	return name == "eth0"
+}
+
 // IsWSL returns true when running inside Windows Subsystem for Linux.
 // It checks for WSLInterop, which is a WSL-specific file that does not exist
 // on native Linux (including Azure/Hyper-V VMs that also carry "microsoft" in

--- a/internal/scanner/ip4/wsl/wsl.go
+++ b/internal/scanner/ip4/wsl/wsl.go
@@ -1,0 +1,14 @@
+package wsl
+
+import (
+	"os"
+)
+
+// IsWSL returns true when running inside Windows Subsystem for Linux.
+// It checks for WSLInterop, which is a WSL-specific file that does not exist
+// on native Linux (including Azure/Hyper-V VMs that also carry "microsoft" in
+// /proc/version), macOS, or Windows.
+func IsWSL() bool {
+	_, err := os.Stat("/proc/sys/fs/binfmt_misc/WSLInterop")
+	return err == nil
+}


### PR DESCRIPTION
can now scan windows interfaces from inside wsl. closes #26
windows interfaces marked win:
better docker support, can now use docker sockets.
docker interface scans are now much faster.